### PR TITLE
FISH-334 Exclude healthcheck-metrics.jar from DI TCK

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -44,6 +44,7 @@
 			<exclude name="modules/microprofile-fault-tolerance.jar"/>
 			<exclude name="modules/microprofile-config.jar"/>
 			<exclude name="modules/microprofile-metrics.jar"/>
+                        <exclude name="modules/healthcheck-metrics.jar"/>
 		</fileset>
 		<fileset dir="${glassfish.home}">
 			<include name="lib/*.jar" />


### PR DESCRIPTION
MicroProfile Metrics implements its own CDI extension and was rightly excluded from the DI TCK classpath, but the new Healthcheck Metrics feature has the MicropProfile Metrics as its dependency. This inevitably caused the MicroProfile Metrics to be included in the classpath of the DI TCK. To fix this issue, I have excluded the Healthcheck Metrics from the classpath.