### PR TITLE
FISH-786: Exclude security connectors from classpath

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -38,7 +38,6 @@
 		<pathelement location="${glassfish.home}/modules/weld-osgi-bundle.jar"/>
 		<fileset dir="${glassfish.home}">
 			<include name="modules/*.jar" />
-			<include name="modules/*.jar" />
 			<exclude name="modules/payara-micro-cdi.jar"/>
 			<exclude name="modules/monitoring-console-core.jar"/>
 			<exclude name="modules/microprofile-fault-tolerance.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -45,6 +45,7 @@
 			<exclude name="modules/microprofile-config.jar"/>
 			<exclude name="modules/microprofile-metrics.jar"/>
                         <exclude name="modules/healthcheck-metrics.jar"/>
+                        <exclude name="modules/security-connector-oidc-client.jar"/>
 		</fileset>
 		<fileset dir="${glassfish.home}">
 			<include name="lib/*.jar" />


### PR DESCRIPTION
They depend on microprofile-config, which is also excluded.

The parent git repo also needs to be updated: https://github.com/payara/jakartaeetck-runner/tree/master/di